### PR TITLE
Implement pushd/popd utilities

### DIFF
--- a/pushit.py
+++ b/pushit.py
@@ -1,0 +1,125 @@
+import os
+import sys 
+
+from pathlib import Path
+from contextlib import ContextDecorator
+from collections import deque
+
+    
+
+class pushit(ContextDecorator):
+    ''' A mix between a queue and a context manager.If used as a context manager, pushit will always
+    return to PWD.'''
+    home = os.environ['HOMEPATH'] if sys.platform[:3] == 'win' else os.environ['HOME']
+    q = deque()
+
+    def __init__(self,*args, **kwargs):
+        super().__init__()
+        self.q = pushit.q
+        self.prev_dir = None
+        self.main = Path(os.getcwd())
+        if args and (type(args[0]) ==str):
+            self.thispath = args[0] 
+        elif args and (type(args[0]) != str):
+            self.fn = args[0]
+        else:
+            self.thispath = None
+    
+    def __call__(self,path=None, chdir=True,**kwargs): # As function
+        ''' Default for pushd is to change to dir when called, and add to queue. 
+        Passing chdir=False remains in current dir, 
+        while still adding to queue'''
+        if not pushit.q:
+            pushit.q.append(self.main)
+        if path:
+            path = self.clean_path(path)
+            if 'right' not in kwargs:
+                pushit.q.appendleft(path)
+            else:
+                pushit.q.append(path)
+        # print('Called with: ',path)
+        if chdir and path:
+            os.chdir(path)
+        return self.fn(path)
+    
+    def __enter__(self):
+        self.prev_dir = os.getcwd()
+        if self.thispath:
+            os.chdir(self.clean_path(self.thispath)) # Just head to dir
+        else:
+            os.chdir(popd(left=True))  # or use queue, LIFO mode
+        return self
+
+    def __exit__(self, *exc):
+        if self.prev_dir and (self.prev_dir != os.getcwd()):
+            os.chdir(self.prev_dir)
+            print('We exited to: ', self.prev_dir)
+        return False 
+    
+    def __repr__(self):
+        current = os.getcwd()
+        print('- {};'.format(current))
+        for ix, obj in enumerate(pushit.q):
+                print(ix,obj.stem)
+      
+        return ''
+    
+    def __iter__(self):
+        ''' Path objects have .stem() if names should be
+        displayed instead'''
+        for obj in pushit.q:
+            yield obj
+    
+    def clean_path(self, path):
+        if '~' in path:
+            path = Path(pushit.home) / path.lstrip('~/')
+        else:
+            path = Path(os.getcwd()) / path
+        if '.' in str(path):
+            path = path.resolve()
+        if path.is_dir():
+            return path
+        raise FileNotFoundError(f'FileNotFoundError: Unable to locate path specified "{path}".')
+
+    def clear(self):
+        '''Start fresh from original call location '''
+        pushit.q.clear()
+        os.chdir(self.main)
+        
+@pushit 
+def pushd(file):
+    pass
+
+def popd(path=None, left=None, save=False):
+    '''If path is specifed, path will be removed
+    save kwarg is for when popd shoud 'echo' the dir instead of
+    remove it'''
+    obj = None
+    if path:
+        try:
+            pushit.q.remove(path)
+        except ValueError:
+            print(f'Unable to locate "{path}" ')
+    else:
+        if left:
+            left = False
+            try:
+                obj = pushit.q.popleft()
+            except IndexError:
+                print('Pushd does not contain any dirs')
+            else:
+                left = True
+        else:
+            right = False
+            try:
+                obj = pushit.q.pop()
+            except IndexError:
+                print('Pushd does not contain any dirs')
+            else:
+                right = True
+    obj = str(obj)
+    if save and left:
+        pushd(obj)
+    elif save and right:
+        pushd(obj, right=True) 
+    return obj

--- a/pushit.py
+++ b/pushit.py
@@ -53,7 +53,6 @@ class pushit(ContextDecorator):
     def __exit__(self, *exc):
         if self.prev_dir and (self.prev_dir != os.getcwd()):
             os.chdir(self.prev_dir)
-            print('We exited to: ', self.prev_dir)
         return False 
     
     def __repr__(self):

--- a/pushit_test.py
+++ b/pushit_test.py
@@ -1,0 +1,89 @@
+import os
+
+from pushit import pushd, pushit
+
+print('Running "pushit/psuhd" demo..\n')
+# dirs can be traced from home or by cwd only
+print('Echo:\n',pushd)
+print('-' * 50)
+print('Empty call:\n',pushd())
+print('-' * 50)
+
+print('Single dir addition:') 
+pushd('test', chdir=False) 
+print('Empty Call:\n',pushd())
+print('-' * 50)
+
+print('Single dir addition w/o dir change: *Incorrect way*')
+try:
+    pushd('test1', chdir=False) # This will raise an Error
+except FileNotFoundError as e:
+    print(e)
+print('Echo:\n',pushd)
+print('-'*50)
+
+print('Single dir addition w/o dir change: *correct way*')
+try:
+    pushd('test/test1', chdir=False) # Correct path specifed from current location of pushd
+except FileNotFoundError as e:
+    print(e)
+else:
+    print('Exception did not raise!')
+print('Echo:\n',pushd)
+print('-'*50)
+
+print('Append right w/ dir change:')
+pushd('test/test1', right=True)
+print('Echo:\n',pushd)
+print('-'*50)
+
+print('From home dir')
+pushd('~')
+print('Echo:\n',pushd)
+
+print('-'*50)
+print('--Start--')
+print(pushd)
+
+print('\n--Context mgr--')
+print('CM--withoutargs')
+with pushit() as f:
+    print('Begin for loop')
+    for obj in f:
+        print('No arg: ',obj)
+
+print('Echo: ', pushd)
+print('Now clearing...')
+pushd.clear()
+print('Echo: ', pushd)
+print('...All Clear!')
+print('-' * 50)
+print('Single dir addition w/ dir change and queue instantion')
+pushd('test')
+print('Echo: ', pushd)
+print('Another one...')
+pushd('test1')
+print('But wait..Now using relative paths')
+pushd('../..')
+print('Echo: ',pushd)
+print('-'* 50)
+print('\n--Context mgr 3 levels--') 
+with pushit() as foo:
+    print('Level 1. Doing stuff in: ', os.getcwd())
+    with pushit() as bar:
+        print('LEvel 2. Doing stuff in: ', os.getcwd())
+        with pushit() as f:
+            print('Level 3. Doing stuff in: ', os.getcwd())  
+            print(f)
+        print('Returned to Level 2: ', os.getcwd())
+    print('Return to level 1: ', os.getcwd())
+print('-'*50)
+print('Echo: ', pushd)
+
+
+print('--ContextMgr with args--')
+with pushit('../..') as f:
+    print('Do stuff here')
+    print('CWD: ',os.getcwd())
+
+print('Echo: ', pushd)

--- a/pushit_test.py
+++ b/pushit_test.py
@@ -1,8 +1,20 @@
 import os
+from pathlib import Path
+from pushit_trace import pushd, pushit, popd
 
-from pushit import pushd, pushit
+def add_init():
+    with open('__init__.py', 'w'): pass 
 
-print('Running "pushit/psuhd" demo..\n')
+def remove_init():
+    inpath = Path(os.getcwd()) / '__init__.py'
+
+    os.remove(inpath)
+
+os.makedirs('pushtest/pushtest1/pushtest2')
+
+
+
+print('Running "pushit/pushd" demo..\n')
 # dirs can be traced from home or by cwd only
 print('Echo:\n',pushd)
 print('-' * 50)
@@ -10,7 +22,7 @@ print('Empty call:\n',pushd())
 print('-' * 50)
 
 print('Single dir addition:') 
-pushd('test', chdir=False) 
+pushd('pushtest', chdir=False) 
 print('Empty Call:\n',pushd())
 print('-' * 50)
 
@@ -24,7 +36,7 @@ print('-'*50)
 
 print('Single dir addition w/o dir change: *correct way*')
 try:
-    pushd('test/test1', chdir=False) # Correct path specifed from current location of pushd
+    pushd('pushtest/pushtest1', chdir=False) # Correct path specifed from current location of pushd
 except FileNotFoundError as e:
     print(e)
 else:
@@ -33,7 +45,7 @@ print('Echo:\n',pushd)
 print('-'*50)
 
 print('Append right w/ dir change:')
-pushd('test/test1', right=True)
+pushd('pushtest/pushtest1', right=True)
 print('Echo:\n',pushd)
 print('-'*50)
 
@@ -59,24 +71,27 @@ print('Echo: ', pushd)
 print('...All Clear!')
 print('-' * 50)
 print('Single dir addition w/ dir change and queue instantion')
-pushd('test')
+pushd('pushtest')
 print('Echo: ', pushd)
 print('Another one...')
-pushd('test1')
+pushd('pushtest1')
 print('But wait..Now using relative paths')
 pushd('../..')
 print('Echo: ',pushd)
 print('-'* 50)
-print('\n--Context mgr 3 levels--') 
+pushd.clear()
+print('\n--Context mgr 3 levels--')
+pushd('pushtest', chdir=False)
+pushd('pushtest/pushtest1', chdir=False)
+pushd('pushtest/pushtest1/pushtest2', chdir=False)
+
 with pushit() as foo:
-    print('Level 1. Doing stuff in: ', os.getcwd())
+    add_init()
     with pushit() as bar:
-        print('LEvel 2. Doing stuff in: ', os.getcwd())
+        add_init()
         with pushit() as f:
-            print('Level 3. Doing stuff in: ', os.getcwd())  
-            print(f)
-        print('Returned to Level 2: ', os.getcwd())
-    print('Return to level 1: ', os.getcwd())
+                add_init()
+                print(f)
 print('-'*50)
 print('Echo: ', pushd)
 
@@ -86,4 +101,17 @@ with pushit('../..') as f:
     print('Do stuff here')
     print('CWD: ',os.getcwd())
 
+popd()
+pushd('pushtest', chdir=False)
+pushd('pushtest/pushtest1', chdir=False)
+pushd('pushtest/pushtest1/pushtest2', chdir=False)
 print('Echo: ', pushd)
+input('Press any key to remove newly created files/dir')
+with pushit() as f:
+    with pushit() as b:
+        with pushit() as foo:
+            remove_init()
+        remove_init()
+    remove_init()
+
+os.removedirs('pushtest/pushtest1/pushtest2')

--- a/pushit_test.py
+++ b/pushit_test.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from pushit_trace import pushd, pushit, popd
+from pushit import pushd, pushit, popd
 
 def add_init():
     with open('__init__.py', 'w'): pass 


### PR DESCRIPTION
So i wasnt sure exactly where to try and implement this. I've created more of a tool set. `Pushd`, `popd`, `pushit`. Basically, `pushd` is a tool that keeps a queue of dirs, which works in a similar fashion to the linux pushd command. `pushd` will echo the CWD as well as the dirs that have been added to the queue. This command, `pushd` takes place of the 'dirs' linux command. The list of dirs that `pushd` echos,  will be displayed in the order it was inserted 0 being most recent and this is the order will be popped on default operation, when calling popd. The way to use `pushd` is like pushd in linux. Call it with a dir, but this also gives functionality of adding dirs to the front or back of the queue. Now type `popd()` to simply remove the dir at the end of the queue or use specify if you want to remove the dir at the front. Use `pushit()` <b>[no args]</b> in a context manger and it will change to the dir next in the queue and remove that dir from the queue while staying inside the cwd. `pushit( <..file>)` in a context manager is also ok too, this dir will be the dir used. It supports nested with-statements to allow to easily run code in different locations of the stack and returning to the cwd at the end of the outher-mostl with block. For-loops can be used to allow no dir change and no removal `For a in psuhd:`. Sorry if this is an overly complicated list and it is unable to be used. I got carried away and realize i wasnt sure where to put this. I was thinking of using it to allow for multipe students (popping in and out of their dirs) or multiple homework assignments, or both combined. But the logic of pygrader seems to be tied to doing one (student/hw) at a time so i didnt try and intergrate this tool. I think pygrader is pretty cool as it is.  I left a test module to show how it runs. Any feeback is much appreciated, and i do thank you for your time and patience. I do think its kinda cool though so ill be turning thhe pushit tool into a package LOL.